### PR TITLE
Wrap FetchGame methods in single try-catch

### DIFF
--- a/GameStoreApi/Controllers/GameController.cs
+++ b/GameStoreApi/Controllers/GameController.cs
@@ -17,17 +17,17 @@ public class GameController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> GetGames([FromQuery] int? id)
     {
-        if (id.HasValue)
-        {
-            var game = await _gameService.FetchGameByIdAsync(id.Value);
-
-            if (game == null) return NotFound($"Game with ID {id.Value} not found.");
-
-            return Ok(game);
-        }
-        
         try
         {
+            if (id.HasValue)
+            {
+                var game = await _gameService.FetchGameByIdAsync(id.Value);
+
+                if (game == null) return NotFound($"Game with ID {id.Value} not found.");
+
+                return Ok(game);
+            }
+            
             var games = await _gameService.FetchGamesAsync();
             return Ok(games);
         }


### PR DESCRIPTION
Wrapped both FetchGames and FetchGamesById in single try-catch to avoid code repition when introducing exception handling for the latter as both are most commonly susceptible to HttpRequestException at this stage due to timeout issues